### PR TITLE
Solution: 02 Generic constraints

### DIFF
--- a/src/01-generics-intro/02-generic-constraints.problem.ts
+++ b/src/01-generics-intro/02-generic-constraints.problem.ts
@@ -1,7 +1,7 @@
 import { it } from "vitest";
 import { Equal, Expect } from "../helpers/type-utils";
 
-export const returnWhatIPassIn = <T>(t: T) => t;
+export const returnWhatIPassIn = <T extends string>(t: T) => t;
 
 it("Should ONLY allow strings to be passed in", () => {
   const a = returnWhatIPassIn("a");


### PR DESCRIPTION
## My solution
```ts 
export const returnWhatIPassIn = <T extends string>(t: T) => t;
```

## Explanation
The solution is by using `extends` to restrict what type being passed into the function