### PR TITLE
Solution: 03 Multiple generics

### DIFF
--- a/src/01-generics-intro/03-multiple-generics.problem.ts
+++ b/src/01-generics-intro/03-multiple-generics.problem.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import { Equal, Expect } from "../helpers/type-utils";
 
-const returnBothOfWhatIPassIn = (a: unknown, b: unknown) => {
+const returnBothOfWhatIPassIn = <T, U>(a: T, b: U) => {
   return {
     a,
     b,


### PR DESCRIPTION
## My solution
```ts
const returnBothOfWhatIPassIn = <T, U>(a: T, b: U) => {
  return {
    a,
    b,
  };
};
```

## Explanation
In the solution, we have to declare 2 generics, each generic to capture each params.


## Notes
Matt explains since we are using multiple generics and arguments. Typescript will be more cautious on how it infers the type.
So, the type will be returned like this.

```ts
{
  a: string;
  b: number;
}
```

Instead of specific type like this
```ts
{
  a: "a";
  b: 1;
}
```