### PR TITLE
Solution: 04 Multiple generics per object

### DIFF
--- a/src/01-generics-intro/04-multiple-generics-per-object.problem.ts
+++ b/src/01-generics-intro/04-multiple-generics-per-object.problem.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import { Equal, Expect } from "../helpers/type-utils";
 
-const returnBothOfWhatIPassIn = (params: { a: unknown; b: unknown }) => {
+const returnBothOfWhatIPassIn = <A, B>(params: { a: A; b: B }) => {
   return {
     first: params.a,
     second: params.b,


### PR DESCRIPTION
## My solution
```ts
const returnBothOfWhatIPassIn = <A, B>(params: { a: A; b: B }) => {
  return {
    first: params.a,
    second: params.b,
  };
};
```

## Explanation
In the solution, we need to declare 2 pieces of generics and then use each generic to capture the value of each params.