### PR TITLE
Solution: 06 Generic mapper

### DIFF
--- a/src/01-generics-intro/06-generic-mapper.problem.ts
+++ b/src/01-generics-intro/06-generic-mapper.problem.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import { Equal, Expect } from "../helpers/type-utils";
 
-export const concatenateFirstNameAndLastName = (user: unknown) => {
+export const concatenateFirstNameAndLastName = <TUser extends {firstName: string; lastName: string}>(user: TUser) => {
   return {
     ...user,
     fullName: `${user.firstName} ${user.lastName}`,


### PR DESCRIPTION
## My solution
```ts
export const concatenateFirstNameAndLastName = <TUser extends {firstName: string; lastName: string}>(user: TUser) => {
```

## Explanation
We need to declare a generic `TUser` and then constraint it to contain `firstName` and `lastName` as `string`