### PR TITLE
Solution: 08 Default generics

### DIFF
--- a/src/02-passing-type-arguments/08-default-generics.problem.ts
+++ b/src/02-passing-type-arguments/08-default-generics.problem.ts
@@ -1,6 +1,6 @@
 import { Equal, Expect } from "../helpers/type-utils";
 
-export const createSet = <T>() => {
+export const createSet = <T = string>() => {
   return new Set<T>();
 };
 


### PR DESCRIPTION
## My solution
```ts
export const createSet = <T = string>() => {
  return new Set<T>();
};
```

## Explanation
For the solution, we can add a default value to generic by adding this tiny bit of syntax `<T = string>`