### PR TITLE
Solution: 09 Generics in type arguments in arguments

### DIFF
--- a/src/02-passing-type-arguments/09-generics-in-type-arguments-in-arguments.problem.ts
+++ b/src/02-passing-type-arguments/09-generics-in-type-arguments-in-arguments.problem.ts
@@ -11,7 +11,7 @@ export class Component<TProps> {
   getProps = () => this.props;
 }
 
-const cloneComponent = (component: unknown) => {
+const cloneComponent = <T>(component: Component<T>) => {
   return new Component(component.getProps());
 };
 


### PR DESCRIPTION
## My solution
```ts
const cloneComponent = <T>(component: Component<T>) => {
  return new Component(component.getProps());
};
```

## Explanation
For the solution, we need to use the `class Component` itself to type the component props. 
Since the class Component requires 1 generic, we can define arbitrary generic to sastisfy it.