### PR TITLE
Solution: 10 Reduce

### DIFF
--- a/src/02-passing-type-arguments/10-reduce.problem.ts
+++ b/src/02-passing-type-arguments/10-reduce.problem.ts
@@ -10,7 +10,7 @@ const array = [
   },
 ];
 
-const obj = array.reduce((accum, item) => {
+const obj = array.reduce< Record<string, { name: string }>>((accum, item) => {
   accum[item.name] = item;
   return accum;
 }, {});


### PR DESCRIPTION
## My solution
```ts
const obj = array.reduce<Record<string, { name: string }>>((accum, item) => {
  accum[item.name] = item;
  return accum;
}, {});
```

## Explanation
Reduce can accept 1 generic to type the return value of the function. We can use that generic slot to type the expected returned value which is `Record<string, { name: string }>`