### PR TITLE
Solution 12: Generics at different levels

### DIFF
--- a/src/03-art-of-type-arguments/12-generics-at-different-levels.problem.ts
+++ b/src/03-art-of-type-arguments/12-generics-at-different-levels.problem.ts
@@ -1,18 +1,22 @@
-import { expect, it, describe } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it, describe } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-export const getHomePageFeatureFlags = (
-  config: unknown,
-  override: (flags: unknown) => unknown
+export const getHomePageFeatureFlags = <
+  TConfig extends { rawConfig: { featureFlags: { homePage: any } } }
+>(
+  config: TConfig,
+  override: (
+    flags: TConfig['rawConfig']['featureFlags']['homePage']
+  ) => TConfig['rawConfig']['featureFlags']['homePage']
 ) => {
-  return override(config.rawConfig.featureFlags.homePage);
-};
+  return override(config.rawConfig.featureFlags.homePage)
+}
 
-describe("getHomePageFeatureFlags", () => {
+describe('getHomePageFeatureFlags', () => {
   const EXAMPLE_CONFIG = {
-    apiEndpoint: "https://api.example.com",
-    apiVersion: "v1",
-    apiKey: "1234567890",
+    apiEndpoint: 'https://api.example.com',
+    apiVersion: 'v1',
+    apiKey: '1234567890',
     rawConfig: {
       featureFlags: {
         homePage: {
@@ -25,36 +29,37 @@ describe("getHomePageFeatureFlags", () => {
         },
       },
     },
-  };
-  it("Should return the homePage flag object", () => {
+  }
+
+  it('Should return the homePage flag object', () => {
     const flags = getHomePageFeatureFlags(
       EXAMPLE_CONFIG,
       (defaultFlags) => defaultFlags
-    );
+    )
 
     expect(flags).toEqual({
       showBanner: true,
       showLogOut: false,
-    });
+    })
 
     type tests = [
       Expect<Equal<typeof flags, { showBanner: boolean; showLogOut: boolean }>>
-    ];
-  });
+    ]
+  })
 
-  it("Should allow you to modify the result", () => {
+  it('Should allow you to modify the result', () => {
     const flags = getHomePageFeatureFlags(EXAMPLE_CONFIG, (defaultFlags) => ({
       ...defaultFlags,
       showBanner: false,
-    }));
+    }))
 
     expect(flags).toEqual({
       showBanner: false,
       showLogOut: false,
-    });
+    })
 
     type tests = [
       Expect<Equal<typeof flags, { showBanner: boolean; showLogOut: boolean }>>
-    ];
-  });
-});
+    ]
+  })
+})


### PR DESCRIPTION
## My solution
```ts
export const getHomePageFeatureFlags = <
  TConfig extends { rawConfig: { featureFlags: { homePage: any } } }
>(
  config: TConfig,
  override: (
    flags: TConfig['rawConfig']['featureFlags']['homePage']
  ) => TConfig['rawConfig']['featureFlags']['homePage']
) => {
  return override(config.rawConfig.featureFlags.homePage)
}
```

## Explanation
First, we need to declare the shape of the config in the generic slot.
```ts
export const getHomePageFeatureFlags = <
  TConfig extends { rawConfig: { featureFlags: { homePage: any } } }
>
```
And then we can use the specific `homePage` key to type the params and return value of override function.
`TConfig['rawConfig']['featureFlags']['homePage']`


## Notes
In the course, Matt comes up with a better solution by using the low level generic definition.
```ts
export const getHomePageFeatureFlags = <HomePageFlags>(
  config: {
    rawConfig: {
      featureFlags: {
        homePage: HomePageFlags;
      };
    };
  },
  override: (flags: HomePageFlags) => HomePageFlags
) => {
  return override(config.rawConfig.featureFlags.homePage);
};
``` 