### PR TITLE
Solution: 13 Typed object keys

### DIFF
--- a/src/03-art-of-type-arguments/13-typed-object-keys.problem.ts
+++ b/src/03-art-of-type-arguments/13-typed-object-keys.problem.ts
@@ -1,22 +1,22 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
 /**
  * There are two possible solutions to this problem - and it's
  * to do with the way you specify the generic. Can you get
  * both solutions?
  */
-const typedObjectKeys = (obj: unknown) => {
-  return Object.keys(obj);
-};
+const typedObjectKeys = <T extends object>(obj: T) => {
+  return Object.keys(obj) as (keyof T)[]
+}
 
-it("Should return the keys of the object", () => {
+it('Should return the keys of the object', () => {
   const result1 = typedObjectKeys({
     a: 1,
     b: 2,
-  });
+  })
 
-  expect(result1).toEqual(["a", "b"]);
+  expect(result1).toEqual(['a', 'b'])
 
-  type test = Expect<Equal<typeof result1, Array<"a" | "b">>>;
-});
+  type test = Expect<Equal<typeof result1, Array<'a' | 'b'>>>
+})

--- a/src/03-art-of-type-arguments/14-safe-function.problem.ts
+++ b/src/03-art-of-type-arguments/14-safe-function.problem.ts
@@ -1,103 +1,103 @@
-import { expect, it } from 'vitest'
-import { Equal, Expect } from '../helpers/type-utils'
+import { expect, it } from "vitest";
+import { Equal, Expect } from "../helpers/type-utils";
 
 const makeSafe =
-  <TArgs extends Array<any>, TResult>(func: (...args: TArgs) => TResult) =>
+  (func: unknown) =>
   (
-    ...args: TArgs
+    ...args: unknown
   ):
     | {
-        type: 'success'
-        result: TResult
+        type: "success";
+        result: unknown;
       }
     | {
-        type: 'failure'
-        error: Error
+        type: "failure";
+        error: Error;
       } => {
     try {
-      const result = func(...args)
+      const result = func(...args);
 
       return {
-        type: 'success',
+        type: "success",
         result,
-      }
+      };
     } catch (e) {
       return {
-        type: 'failure',
+        type: "failure",
         error: e as Error,
-      }
+      };
     }
-  }
+  };
 
 it("Should return the result with a { type: 'success' } on a successful call", () => {
-  const func = makeSafe(() => 1)
+  const func = makeSafe(() => 1);
 
-  const result = func()
+  const result = func();
 
   expect(result).toEqual({
-    type: 'success',
+    type: "success",
     result: 1,
-  })
+  });
 
   type tests = [
     Expect<
       Equal<
         typeof result,
         | {
-            type: 'success'
-            result: number
+            type: "success";
+            result: number;
           }
         | {
-            type: 'failure'
-            error: Error
+            type: "failure";
+            error: Error;
           }
       >
-    >
-  ]
-})
+    >,
+  ];
+});
 
-it('Should return the error on a thrown call', () => {
+it("Should return the error on a thrown call", () => {
   const func = makeSafe(() => {
     if (1 > 2) {
-      return '123'
+      return "123";
     }
-    throw new Error('Oh dear')
-  })
+    throw new Error("Oh dear");
+  });
 
-  const result = func()
+  const result = func();
 
   expect(result).toEqual({
-    type: 'failure',
-    error: new Error('Oh dear'),
-  })
+    type: "failure",
+    error: new Error("Oh dear"),
+  });
 
   type tests = [
     Expect<
       Equal<
         typeof result,
         | {
-            type: 'success'
-            result: string
+            type: "success";
+            result: string;
           }
         | {
-            type: 'failure'
-            error: Error
+            type: "failure";
+            error: Error;
           }
       >
-    >
-  ]
-})
+    >,
+  ];
+});
 
 it("Should properly match the function's arguments", () => {
   const func = makeSafe((a: number, b: string) => {
-    return `${a} ${b}`
-  })
+    return `${a} ${b}`;
+  });
 
   // @ts-expect-error
-  func()
+  func();
 
   // @ts-expect-error
-  func(1, 1)
+  func(1, 1);
 
-  func(1, '1')
-})
+  func(1, "1");
+});

--- a/src/03-art-of-type-arguments/14-safe-function.problem.ts
+++ b/src/03-art-of-type-arguments/14-safe-function.problem.ts
@@ -1,103 +1,103 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
 const makeSafe =
-  (func: unknown) =>
+  <TArgs extends Array<any>, TResult>(func: (...args: TArgs) => TResult) =>
   (
-    ...args: unknown
+    ...args: TArgs
   ):
     | {
-        type: "success";
-        result: unknown;
+        type: 'success'
+        result: TResult
       }
     | {
-        type: "failure";
-        error: Error;
+        type: 'failure'
+        error: Error
       } => {
     try {
-      const result = func(...args);
+      const result = func(...args)
 
       return {
-        type: "success",
+        type: 'success',
         result,
-      };
+      }
     } catch (e) {
       return {
-        type: "failure",
+        type: 'failure',
         error: e as Error,
-      };
+      }
     }
-  };
+  }
 
 it("Should return the result with a { type: 'success' } on a successful call", () => {
-  const func = makeSafe(() => 1);
+  const func = makeSafe(() => 1)
 
-  const result = func();
+  const result = func()
 
   expect(result).toEqual({
-    type: "success",
+    type: 'success',
     result: 1,
-  });
+  })
 
   type tests = [
     Expect<
       Equal<
         typeof result,
         | {
-            type: "success";
-            result: number;
+            type: 'success'
+            result: number
           }
         | {
-            type: "failure";
-            error: Error;
+            type: 'failure'
+            error: Error
           }
       >
-    >,
-  ];
-});
+    >
+  ]
+})
 
-it("Should return the error on a thrown call", () => {
+it('Should return the error on a thrown call', () => {
   const func = makeSafe(() => {
     if (1 > 2) {
-      return "123";
+      return '123'
     }
-    throw new Error("Oh dear");
-  });
+    throw new Error('Oh dear')
+  })
 
-  const result = func();
+  const result = func()
 
   expect(result).toEqual({
-    type: "failure",
-    error: new Error("Oh dear"),
-  });
+    type: 'failure',
+    error: new Error('Oh dear'),
+  })
 
   type tests = [
     Expect<
       Equal<
         typeof result,
         | {
-            type: "success";
-            result: string;
+            type: 'success'
+            result: string
           }
         | {
-            type: "failure";
-            error: Error;
+            type: 'failure'
+            error: Error
           }
       >
-    >,
-  ];
-});
+    >
+  ]
+})
 
 it("Should properly match the function's arguments", () => {
   const func = makeSafe((a: number, b: string) => {
-    return `${a} ${b}`;
-  });
+    return `${a} ${b}`
+  })
 
   // @ts-expect-error
-  func();
+  func()
 
   // @ts-expect-error
-  func(1, 1);
+  func(1, 1)
 
-  func(1, "1");
-});
+  func(1, '1')
+})


### PR DESCRIPTION
## My solution
```ts
const typedObjectKeys = <T extends object>(obj: T) => {
  return Object.keys(obj) as (keyof T)[]
}
```

## Explanation
First, we need to declare a generic slot `T` that constrained by object type to be able to pass the `Object.keys()` method.
And then, we can do assertion to give a type into the return value

## Solution
The proposed solution by Matt is to declare the generic at key level, by doing this the captured type in VSCode will be cleaner.

```ts
const typedObjectKeys = <TKey extends string>(obj: Record<TKey, any>) => {
  return Object.keys(obj) as Array<TKey>;
};
```