### PR TITLE
Solution: 14.7 String number union

### DIFF
--- a/src/03-art-of-type-arguments/14.7-string-number-union.problem.ts
+++ b/src/03-art-of-type-arguments/14.7-string-number-union.problem.ts
@@ -1,23 +1,23 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-export const inferItemLiteral = <T>(t: T) => {
+export const inferItemLiteral = <T extends string | number>(t: T) => {
   return {
     output: t,
-  };
-};
+  }
+}
 
-const result1 = inferItemLiteral("a");
-const result2 = inferItemLiteral(123);
+const result1 = inferItemLiteral('a')
+const result2 = inferItemLiteral(123)
 
 type tests = [
-  Expect<Equal<typeof result1, { output: "a" }>>,
+  Expect<Equal<typeof result1, { output: 'a' }>>,
   Expect<Equal<typeof result2, { output: 123 }>>
-];
+]
 
 // @ts-expect-error
 const error1 = inferItemLiteral({
   a: 1,
-});
+})
 
 // @ts-expect-error
-const error2 = inferItemLiteral([1, 2]);
+const error2 = inferItemLiteral([1, 2])


### PR DESCRIPTION
## My solution
```ts
export const inferItemLiteral = <T extends string | number>(t: T) => {
```

## Explanation
To infer as literal type then we can constrain it into the type that we expect.