### PR TITLE
Solution: 15 Array or array member in generics

### DIFF
--- a/src/03-art-of-type-arguments/15-array-or-array-member-in-generics.problem.ts
+++ b/src/03-art-of-type-arguments/15-array-or-array-member-in-generics.problem.ts
@@ -1,11 +1,11 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-const makeStatus = <TStatuses extends string[]>(statuses: TStatuses) => {
-  return statuses;
-};
+const makeStatus = <TStatuses extends string>(statuses: TStatuses[]) => {
+  return statuses
+}
 
-const statuses = makeStatus(["INFO", "DEBUG", "ERROR", "WARNING"]);
+const statuses = makeStatus(['INFO', 'DEBUG', 'ERROR', 'WARNING'])
 
 type tests = [
-  Expect<Equal<typeof statuses, Array<"INFO" | "DEBUG" | "ERROR" | "WARNING">>>,
-];
+  Expect<Equal<typeof statuses, Array<'INFO' | 'DEBUG' | 'ERROR' | 'WARNING'>>>
+]


### PR DESCRIPTION
## My solution
```ts
const makeStatus = <TStatuses extends string>(statuses: TStatuses[]) => {
  return statuses
}
```

## Explanation
The key to solve this problem is by placing the generic as close as possible to the item that we want to infer. 
Here we want to infer the array element, then we can make our generic slot to constraint as string and make the params as array of elements.