### PR TITLE
Solution: 16 Class names creator

### DIFF
--- a/src/03-art-of-type-arguments/16-class-names-creator.problem.ts
+++ b/src/03-art-of-type-arguments/16-class-names-creator.problem.ts
@@ -1,49 +1,49 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
 const createClassNamesFactory =
-  (classes: unknown) =>
-  (type: unknown, ...otherClasses: unknown[]) => {
-    const classList = [classes[type], ...otherClasses];
-    return classList.join(" ");
-  };
+  <TClass extends string>(classes: Record<TClass, string>) =>
+  (type: TClass, ...otherClasses: string[]) => {
+    const classList = [classes[type], ...otherClasses]
+    return classList.join(' ')
+  }
 
 const getBg = createClassNamesFactory({
-  primary: "bg-blue-500",
-  secondary: "bg-gray-500",
-});
+  primary: 'bg-blue-500',
+  secondary: 'bg-gray-500',
+})
 
-it("Should let you create classes from a className factory", () => {
-  expect(getBg("primary")).toEqual("bg-blue-500");
-  expect(getBg("secondary")).toEqual("bg-gray-500");
-});
+it('Should let you create classes from a className factory', () => {
+  expect(getBg('primary')).toEqual('bg-blue-500')
+  expect(getBg('secondary')).toEqual('bg-gray-500')
+})
 
-it("Should let you pass additional classes which get appended", () => {
-  expect(getBg("primary", "text-white", "rounded", "p-4")).toEqual(
-    "bg-blue-500 text-white rounded p-4"
-  );
-});
+it('Should let you pass additional classes which get appended', () => {
+  expect(getBg('primary', 'text-white', 'rounded', 'p-4')).toEqual(
+    'bg-blue-500 text-white rounded p-4'
+  )
+})
 
-it("Should return a type of string", () => {
-  const result = getBg("primary");
+it('Should return a type of string', () => {
+  const result = getBg('primary')
 
-  type test = Expect<Equal<typeof result, string>>;
-});
+  type test = Expect<Equal<typeof result, string>>
+})
 
-it("Should not let you pass invalid variants", () => {
+it('Should not let you pass invalid variants', () => {
   // @ts-expect-error
-  getBg("123123");
-});
+  getBg('123123')
+})
 
-it("Should not let you pass an invalid object to createClassNamesFactory", () => {
+it('Should not let you pass an invalid object to createClassNamesFactory', () => {
   // @ts-expect-error
-  createClassNamesFactory([]);
+  createClassNamesFactory([])
 
   // @ts-expect-error
-  createClassNamesFactory(123);
+  createClassNamesFactory(123)
 
   createClassNamesFactory({
     // @ts-expect-error
     a: 1,
-  });
-});
+  })
+})


### PR DESCRIPTION
## My solution
```ts
const createClassNamesFactory =
  <TClass extends string>(classes: Record<TClass, string>) =>
  (type: TClass, ...otherClasses: string[]) => {
    const classList = [classes[type], ...otherClasses]
    return classList.join(' ')
  }
```

## Explanation
First, we need to declare a generic slot that refers to the key of className.
```ts
<TClass extends string>
```

After that, we need to declare record of classes, which is the expected value of the initial value.
```ts
  <TClass extends string>(classes: Record<TClass, string>) =>
```

At last, we can use the TClass to declare the accepted type of generated function, and constraint otherClasses with array of string.
```ts
 (type: TClass, ...otherClasses: string[]) => {
```