### PR TITLE
Solution: 17 You say goodbye I say hello

### DIFF
--- a/src/04-generics-advanced/17-you-say-goodbye-i-say-hello.problem.ts
+++ b/src/04-generics-advanced/17-you-say-goodbye-i-say-hello.problem.ts
@@ -1,22 +1,16 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-function youSayGoodbyeISayHello(greeting: unknown) {
-  return greeting === "goodbye" ? "hello" : "goodbye";
+function youSayGoodbyeISayHello<TGreeting extends 'hello' | 'goodbye'>(
+  greeting: TGreeting
+): TGreeting extends 'goodbye' ? 'hello' : 'goodbye' {
+  return (greeting === 'goodbye' ? 'hello' : 'goodbye') as any
 }
 
-it("Should return goodbye when hello is passed in", () => {
-  const result = youSayGoodbyeISayHello("hello");
+it('Should return hello when goodbye is passed in', () => {
+  const result = youSayGoodbyeISayHello('goodbye')
 
-  type test = [Expect<Equal<typeof result, "goodbye">>];
+  type test = [Expect<Equal<typeof result, 'hello'>>]
 
-  expect(result).toEqual("goodbye");
-});
-
-it("Should return hello when goodbye is passed in", () => {
-  const result = youSayGoodbyeISayHello("goodbye");
-
-  type test = [Expect<Equal<typeof result, "hello">>];
-
-  expect(result).toEqual("hello");
-});
+  expect(result).toEqual('hello')
+})


### PR DESCRIPTION
## My solution
```ts
function youSayGoodbyeISayHello<TGreeting extends 'hello' | 'goodbye'>(
  greeting: TGreeting
): TGreeting extends 'goodbye' ? 'hello' : 'goodbye' {
  return (greeting === 'goodbye' ? 'hello' : 'goodbye') as any
}
```

## Explanation
First, we need to declare a generic `TGreeting` and constrain it with the possible input `'hello' | 'goodbye'`.
```ts
function youSayGoodbyeISayHello<TGreeting extends 'hello' | 'goodbye'>(
```

And then after than we can declare the expected return value by using conditional type
```ts
TGreeting extends 'goodbye' ? 'hello' : 'goodbye'
```

At this point, all looks good until the TS compiler will yell at us because the compiler isn't smart enough to know if our run time code satisfy the constrain or not.
![image](https://github.com/kentnathaniel/typescript-generics-workshop/assets/31380193/c3dde627-5adb-4778-9903-31171f01f40e)

To work around this issue, we can use assertion `any`. This tell the compiler that we know the return type will be either `hello` or `goodbye`