### PR TITLE
Solution: 17.5 Inference inside generic functions

### DIFF
--- a/src/04-generics-advanced/17.5-inference-inside-generic-functions.problem.ts
+++ b/src/04-generics-advanced/17.5-inference-inside-generic-functions.problem.ts
@@ -1,28 +1,28 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 type Person = {
-  name: string;
-  age: number;
-  birthdate: Date;
-};
+  name: string
+  age: number
+  birthdate: Date
+}
 
 export function remapPerson<Key extends keyof Person>(
   key: Key,
-  value: Person[Key],
+  value: Person[Key]
 ): Person[Key] {
-  if (key === "birthdate") {
-    return new Date();
+  if (key === 'birthdate') {
+    return new Date() as Person[Key]
   }
 
-  return value;
+  return value
 }
 
-const date = remapPerson("birthdate", new Date());
-const num = remapPerson("age", 42);
-const name = remapPerson("name", "John Doe");
+const date = remapPerson('birthdate', new Date())
+const num = remapPerson('age', 42)
+const name = remapPerson('name', 'John Doe')
 
 type tests = [
   Expect<Equal<typeof date, Date>>,
   Expect<Equal<typeof num, number>>,
-  Expect<Equal<typeof name, string>>,
-];
+  Expect<Equal<typeof name, string>>
+]


### PR DESCRIPTION
## My solution
```ts
if (key === 'birthdate') {
  return new Date() as Person[Key]
}
```

## Explanation
The solution is by using assertion. Why we need to do this, this is because TS can't trust any narrowing inside generic function, users can pass in union of `Key` into `remapPerson` function.