### PR TITLE
Solution: 18 Generic currying

### DIFF
--- a/src/04-generics-advanced/18-generic-currying.problem.ts
+++ b/src/04-generics-advanced/18-generic-currying.problem.ts
@@ -1,27 +1,27 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
 export const curryFunction =
-  <T, U, V>(t: T) =>
-  (u: U) =>
-  (v: V) => {
+  <T>(t: T) =>
+  <U>(u: U) =>
+  <V>(v: V) => {
     return {
       t,
       u,
       v,
-    };
-  };
+    }
+  }
 
-it("Should return an object which matches the types of each input", () => {
-  const result = curryFunction(1)(2)(3);
+it('Should return an object which matches the types of each input', () => {
+  const result = curryFunction(1)(2)(3)
 
   expect(result).toEqual({
     t: 1,
     u: 2,
     v: 3,
-  });
+  })
 
   type test = [
-    Expect<Equal<typeof result, { t: number; u: number; v: number }>>,
-  ];
-});
+    Expect<Equal<typeof result, { t: number; u: number; v: number }>>
+  ]
+})


### PR DESCRIPTION
## My solution
```ts
export const curryFunction =
  <T>(t: T) =>
  <U>(u: U) =>
  <V>(v: V) => {
    return {
      t,
      u,
      v,
    }
  }
```

## Explanation
To solve the issue of type inference inside currying function, we need to declare the generic as close as possible to the declare return function.