### PR TITLE
Solution: 20 Spotting useless generic

### DIFF
--- a/src/04-generics-advanced/20-spotting-useless-generics.problem.ts
+++ b/src/04-generics-advanced/20-spotting-useless-generics.problem.ts
@@ -1,20 +1,24 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-const returnBothOfWhatIPassIn = <T1, T2>(params: {
-  a: T1;
-  b: T2;
-}): [T1, T2] => {
-  return [params.a, params.b];
-};
+const returnBothOfWhatIPassIn = <
+  TParams extends {
+    a: unknown
+    b: unknown
+  }
+>(
+  params: TParams
+): [TParams['a'], TParams['b']] => {
+  return [params.a, params.b]
+}
 
-it("Should return a tuple of the properties a and b", () => {
+it('Should return a tuple of the properties a and b', () => {
   const result = returnBothOfWhatIPassIn({
-    a: "a",
+    a: 'a',
     b: 1,
-  });
+  })
 
-  expect(result).toEqual(["a", 1]);
+  expect(result).toEqual(['a', 1])
 
-  type test1 = Expect<Equal<typeof result, [string, number]>>;
-});
+  type test1 = Expect<Equal<typeof result, [string, number]>>
+})


### PR DESCRIPTION
## My solution
```ts
const returnBothOfWhatIPassIn = <
  TParams extends {
    a: unknown
    b: unknown
  }
>(
  params: TParams
): [TParams['a'], TParams['b']] => {
  return [params.a, params.b]
}
```

## Explanation
I didn't come up with the solution. This is Matt's solution, but the key takeaway here is to try always looking to clean for useless or redundant generic that might be cluttering our project. 
The general idea here is the less generic argument that we use, the easier it is to refactor