### PR TITLE
Solution: 20.5 Spotting missing generics

### DIFF
--- a/src/04-generics-advanced/20.5-spotting-missing-generics.problem.ts
+++ b/src/04-generics-advanced/20.5-spotting-missing-generics.problem.ts
@@ -1,23 +1,23 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-const getValue = <TObj>(obj: TObj, key: keyof TObj) => {
-  return obj[key];
-};
+const getValue = <TObj, TKey extends keyof TObj>(obj: TObj, key: TKey) => {
+  return obj[key]
+}
 
 const obj = {
   a: 1,
-  b: "some-string",
+  b: 'some-string',
   c: true,
-};
+}
 
-const numberResult = getValue(obj, "a");
-const stringResult = getValue(obj, "b");
-const booleanResult = getValue(obj, "c");
+const numberResult = getValue(obj, 'a')
+const stringResult = getValue(obj, 'b')
+const booleanResult = getValue(obj, 'c')
 
 type tests = [
   Expect<Equal<typeof numberResult, number>>,
   Expect<Equal<typeof stringResult, string>>,
-  Expect<Equal<typeof booleanResult, boolean>>,
-];
+  Expect<Equal<typeof booleanResult, boolean>>
+]
 
-export {};
+export {}


### PR DESCRIPTION
## My solution
```ts
const getValue = <TObj, TKey extends keyof TObj>(obj: TObj, key: TKey) => {
  return obj[key]
}

```

## Explanation
The problem in this case is we're trying to access `TObj` with all the possibility keys of it, instead of a key. 
We need to use a different generic to solve this issue, we can call it `TKey` that we constrain by `keyof TObj` to get the autocompletion.