### PR TITLE
Solution: 20.6 Reusable context

### DIFF
--- a/src/04-generics-advanced/20.6-reusable-context.problem.ts
+++ b/src/04-generics-advanced/20.6-reusable-context.problem.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from "react";
+import { CSSProperties } from 'react'
 
 /**
  * In this implementation, we need to specify the theme
@@ -12,26 +12,30 @@ import { CSSProperties } from "react";
  *
  * const useStyled = makeUseStyled<MyTheme>();
  */
-const useStyled = <TTheme = {}>(func: (theme: TTheme) => CSSProperties) => {
-  // Imagine that this function hooks into a global theme
-  // and returns the CSSProperties
-  return {} as CSSProperties;
-};
+const makeUseStyled =
+  <TTheme = {}>() =>
+  (func: (theme: TTheme) => CSSProperties) => {
+    // Imagine that this function hooks into a global theme
+    // and returns the CSSProperties
+    return {} as CSSProperties
+  }
 
 interface MyTheme {
   color: {
-    primary: string;
-  };
+    primary: string
+  }
   fontSize: {
-    small: string;
-  };
+    small: string
+  }
 }
 
-const buttonStyle = useStyled<MyTheme>((theme) => ({
+const useStyled = makeUseStyled<MyTheme>()
+
+const buttonStyle = useStyled((theme) => ({
   color: theme.color.primary,
   fontSize: theme.fontSize.small,
-}));
+}))
 
-const divStyle = useStyled<MyTheme>((theme) => ({
+const divStyle = useStyled((theme) => ({
   backgroundColor: theme.color.primary,
-}));
+}))


### PR DESCRIPTION
## My solution
```ts
const makeUseStyled =
  <TTheme = {}>() =>
  (func: (theme: TTheme) => CSSProperties) => {
    // Imagine that this function hooks into a global theme
    // and returns the CSSProperties
    return {} as CSSProperties
  }
```

```ts
const useStyled = makeUseStyled<MyTheme>()
```

## Explanation
To be able to reduce the redundancy, we have to make `useStyled` generated from a factory.
So the idea here is to make a new layer of abstraction called `makeUseStyled` which accept a `TTheme` and propagate it to the generated `useStyled` function which can be used everywhere with the same Theme.