### PR TITLE
Solution: 20.7 Working around partial inference

### DIFF
--- a/src/04-generics-advanced/20.7-working-around-partial-inference.problem.ts
+++ b/src/04-generics-advanced/20.7-working-around-partial-inference.problem.ts
@@ -1,18 +1,15 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-export const makeSelectors = <
-  TSource,
-  TSelectors extends Record<string, (source: TSource) => any>,
->(
-  selectors: TSelectors,
-) => {
-  return selectors;
-};
+export const makeSelectors = <TSource>() => {
+  return <TSelectors extends Record<string, (source: TSource) => any>>(
+    selectors: TSelectors
+  ) => selectors
+}
 
 interface Source {
-  firstName: string;
-  middleName: string;
-  lastName: string;
+  firstName: string
+  middleName: string
+  lastName: string
 }
 
 /**
@@ -27,19 +24,19 @@ interface Source {
  *
  * makeSelectors<Source>()({ ...selectorsGoHere })
  */
-const selectors = makeSelectors<Source>({
+const selectors = makeSelectors<Source>()({
   getFullName: (source) =>
     `${source.firstName} ${source.middleName} ${source.lastName}`,
   getFirstAndLastName: (source) => `${source.firstName} ${source.lastName}`,
   getFirstNameLength: (source) => source.firstName.length,
-});
+})
 
 type tests = [
-  Expect<Equal<(typeof selectors)["getFullName"], (source: Source) => string>>,
+  Expect<Equal<(typeof selectors)['getFullName'], (source: Source) => string>>,
   Expect<
-    Equal<(typeof selectors)["getFirstAndLastName"], (source: Source) => string>
+    Equal<(typeof selectors)['getFirstAndLastName'], (source: Source) => string>
   >,
   Expect<
-    Equal<(typeof selectors)["getFirstNameLength"], (source: Source) => number>
-  >,
-];
+    Equal<(typeof selectors)['getFirstNameLength'], (source: Source) => number>
+  >
+]


### PR DESCRIPTION
## My solution
Modification in `makeSelectors`
```ts
export const makeSelectors = <TSource>() => {
  return <TSelectors extends Record<string, (source: TSource) => any>>(
    selectors: TSelectors
  ) => selectors
}
```

Modification in `selectors` call
```ts
const selectors = makeSelectors<Source>()({
  getFullName: (source) =>
    `${source.firstName} ${source.middleName} ${source.lastName}`,
  getFirstAndLastName: (source) => `${source.firstName} ${source.lastName}`,
  getFirstNameLength: (source) => source.firstName.length,
})
```

## Explanation
As Matt explains, the way TS works, it can't infer the second argument. 
So to make the TSelectors work, we have to make another abstraction layer. We need to transform makeSelectors as some sort of factory, so that we can have `TSelectors` as the first argument.
