### PR TITLE
Solution: 22 Function overloads vs conditional types

### DIFF
--- a/src/05-function-overloads/22-function-overloads-vs-conditional-types.problem.ts
+++ b/src/05-function-overloads/22-function-overloads-vs-conditional-types.problem.ts
@@ -1,26 +1,29 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
 /**
  * This time, let's try and solve this one
  * with function overloads too!
  */
-export const youSayGoodbyeISayHello = (greeting: "goodbye" | "hello") => {
-  return greeting === "goodbye" ? "hello" : "goodbye";
-};
 
-it("Should return goodbye when hello is passed in", () => {
-  const result = youSayGoodbyeISayHello("hello");
+function youSayGoodbyeISayHello(greeting: 'hello'): 'goodbye'
+function youSayGoodbyeISayHello(greeting: 'goodbye'): 'hello'
+function youSayGoodbyeISayHello(greeting: 'goodbye' | 'hello') {
+  return greeting === 'goodbye' ? 'hello' : 'goodbye'
+}
 
-  type test = [Expect<Equal<typeof result, "goodbye">>];
+it('Should return goodbye when hello is passed in', () => {
+  const result = youSayGoodbyeISayHello('hello')
 
-  expect(result).toEqual("goodbye");
-});
+  type test = [Expect<Equal<typeof result, 'goodbye'>>]
 
-it("Should return hello when goodbye is passed in", () => {
-  const result = youSayGoodbyeISayHello("goodbye");
+  expect(result).toEqual('goodbye')
+})
 
-  type test = [Expect<Equal<typeof result, "hello">>];
+it('Should return hello when goodbye is passed in', () => {
+  const result = youSayGoodbyeISayHello('goodbye')
 
-  expect(result).toEqual("hello");
-});
+  type test = [Expect<Equal<typeof result, 'hello'>>]
+
+  expect(result).toEqual('hello')
+})


### PR DESCRIPTION
## My solution
```ts
function youSayGoodbyeISayHello(greeting: 'hello'): 'goodbye'
function youSayGoodbyeISayHello(greeting: 'goodbye'): 'hello'
```

## Explanation
The solution is by adding 2 function overloads both for `hello` and `goodbye` and then add return signature based on the input.

## Notes
We have to add 2 overloads. 
Because when we have an overloaded function like this, the implementation signature 
```ts
function youSayGoodbyeISayHello(greeting: 'goodbye' | 'hello') 
```
is not exposed outside of the function. This then becomes an internal signature.