### PR TITLE
Solution: 24 Function overloads vs Union types

### DIFF
--- a/src/05-function-overloads/24-function-overloads-vs-union-types.problem.ts
+++ b/src/05-function-overloads/24-function-overloads-vs-union-types.problem.ts
@@ -1,27 +1,31 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-function runGenerator(generator: unknown) {
-  if (typeof generator === "function") {
-    return generator();
+function runGenerator(generator: () => string): string
+function runGenerator(generator: { run: () => string }): string
+function runGenerator(
+  generator: { run: () => string } | (() => string)
+): string {
+  if (typeof generator === 'function') {
+    return generator()
   }
-  return generator.run();
+  return generator.run()
 }
 
-it("Should accept an object where the generator is a function", () => {
+it('Should accept an object where the generator is a function', () => {
   const result = runGenerator({
-    run: () => "hello",
-  });
+    run: () => 'hello',
+  })
 
-  expect(result).toBe("hello");
+  expect(result).toBe('hello')
 
-  type test1 = Expect<Equal<typeof result, string>>;
-});
+  type test1 = Expect<Equal<typeof result, string>>
+})
 
-it("Should accept an object where the generator is a function", () => {
-  const result = runGenerator(() => "hello");
+it('Should accept an object where the generator is a function', () => {
+  const result = runGenerator(() => 'hello')
 
-  expect(result).toBe("hello");
+  expect(result).toBe('hello')
 
-  type test1 = Expect<Equal<typeof result, string>>;
-});
+  type test1 = Expect<Equal<typeof result, string>>
+})

--- a/src/05-function-overloads/24-function-overloads-vs-union-types.problem.ts
+++ b/src/05-function-overloads/24-function-overloads-vs-union-types.problem.ts
@@ -1,11 +1,20 @@
 import { expect, it } from 'vitest'
 import { Equal, Expect } from '../helpers/type-utils'
 
-function runGenerator(generator: () => string): string
-function runGenerator(generator: { run: () => string }): string
-function runGenerator(
+function runGenerator2(generator: () => string): string
+function runGenerator2(generator: { run: () => string }): string
+function runGenerator2(
   generator: { run: () => string } | (() => string)
 ): string {
+  if (typeof generator === 'function') {
+    return generator()
+  }
+  return generator.run()
+}
+
+function runGenerator<TResult>(
+  generator: { run: () => TResult } | (() => TResult)
+) {
   if (typeof generator === 'function') {
     return generator()
   }

--- a/src/05-function-overloads/25-generics-in-function-overloads.problem.ts
+++ b/src/05-function-overloads/25-generics-in-function-overloads.problem.ts
@@ -1,27 +1,29 @@
-import { it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-function returnWhatIPassInExceptFor1(t: unknown): unknown {
+function returnWhatIPassInExceptFor1<T>(t: T): T
+function returnWhatIPassInExceptFor1(t: 1): 2
+function returnWhatIPassInExceptFor1<T>(t: T | 1): T | 2 {
   if (t === 1) {
-    return 2;
+    return 2
   }
-  return t;
+  return t
 }
 
-it("Should return the type 2 when you pass in 1", () => {
-  const result = returnWhatIPassInExceptFor1(1);
+it('Should return the type 2 when you pass in 1', () => {
+  const result = returnWhatIPassInExceptFor1(1)
 
-  type test1 = Expect<Equal<typeof result, 2>>;
-});
+  type test1 = Expect<Equal<typeof result, 2>>
+})
 
-it("Otherwise, should return what you pass in", () => {
-  const a = returnWhatIPassInExceptFor1("a");
-  const b = returnWhatIPassInExceptFor1("b");
-  const c = returnWhatIPassInExceptFor1("c");
+it('Otherwise, should return what you pass in', () => {
+  const a = returnWhatIPassInExceptFor1('a')
+  const b = returnWhatIPassInExceptFor1('b')
+  const c = returnWhatIPassInExceptFor1('c')
 
   type tests = [
-    Expect<Equal<typeof a, "a">>,
-    Expect<Equal<typeof b, "b">>,
-    Expect<Equal<typeof c, "c">>
-  ];
-});
+    Expect<Equal<typeof a, 'a'>>,
+    Expect<Equal<typeof b, 'b'>>,
+    Expect<Equal<typeof c, 'c'>>
+  ]
+})

--- a/src/05-function-overloads/25-generics-in-function-overloads.problem.ts
+++ b/src/05-function-overloads/25-generics-in-function-overloads.problem.ts
@@ -1,29 +1,27 @@
-import { it } from 'vitest'
-import { Equal, Expect } from '../helpers/type-utils'
+import { it } from "vitest";
+import { Equal, Expect } from "../helpers/type-utils";
 
-function returnWhatIPassInExceptFor1<T>(t: T): T
-function returnWhatIPassInExceptFor1(t: 1): 2
-function returnWhatIPassInExceptFor1<T>(t: T | 1): T | 2 {
+function returnWhatIPassInExceptFor1(t: unknown): unknown {
   if (t === 1) {
-    return 2
+    return 2;
   }
-  return t
+  return t;
 }
 
-it('Should return the type 2 when you pass in 1', () => {
-  const result = returnWhatIPassInExceptFor1(1)
+it("Should return the type 2 when you pass in 1", () => {
+  const result = returnWhatIPassInExceptFor1(1);
 
-  type test1 = Expect<Equal<typeof result, 2>>
-})
+  type test1 = Expect<Equal<typeof result, 2>>;
+});
 
-it('Otherwise, should return what you pass in', () => {
-  const a = returnWhatIPassInExceptFor1('a')
-  const b = returnWhatIPassInExceptFor1('b')
-  const c = returnWhatIPassInExceptFor1('c')
+it("Otherwise, should return what you pass in", () => {
+  const a = returnWhatIPassInExceptFor1("a");
+  const b = returnWhatIPassInExceptFor1("b");
+  const c = returnWhatIPassInExceptFor1("c");
 
   type tests = [
-    Expect<Equal<typeof a, 'a'>>,
-    Expect<Equal<typeof b, 'b'>>,
-    Expect<Equal<typeof c, 'c'>>
-  ]
-})
+    Expect<Equal<typeof a, "a">>,
+    Expect<Equal<typeof b, "b">>,
+    Expect<Equal<typeof c, "c">>
+  ];
+});


### PR DESCRIPTION
## My solution
Using function overloads
```ts
function runGenerator(generator: () => string): string
function runGenerator(generator: { run: () => string }): string
function runGenerator(
  generator: { run: () => string } | (() => string)
)
```

Using generic
```ts
function runGenerator<TResult>(
  generator: { run: () => TResult } | (() => TResult)
)
```

## Explanation
This problem can be solved by using both function overload and generic. 
I think by using the function overloads it is a little bit more verbose. Another thing, when using func overloads, it isn't smart enough to infer the return value from our generator, so we have to explicitly declare if it will return `string`

```ts
function runGenerator(generator: () => string): string
```

When using generic, we can get a nice type inference of the return value.


## Notes
I got the wrong idea when solving this problem, Matt wants to explain the difference between using function overloads and just straight up implementation signature.
The key takeaway is if we have the same return for every overloads, we can just use plain implementation signature.