### PR TITLE
Solution: 25 Generics in function overloads

### DIFF
--- a/src/05-function-overloads/25-generics-in-function-overloads.problem.ts
+++ b/src/05-function-overloads/25-generics-in-function-overloads.problem.ts
@@ -1,27 +1,29 @@
-import { it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-function returnWhatIPassInExceptFor1(t: unknown): unknown {
+function returnWhatIPassInExceptFor1<T>(t: T): T
+function returnWhatIPassInExceptFor1(t: 1): 2
+function returnWhatIPassInExceptFor1<T>(t: T | 1): T | 2 {
   if (t === 1) {
-    return 2;
+    return 2
   }
-  return t;
+  return t
 }
 
-it("Should return the type 2 when you pass in 1", () => {
-  const result = returnWhatIPassInExceptFor1(1);
+it('Should return the type 2 when you pass in 1', () => {
+  const result = returnWhatIPassInExceptFor1(1)
 
-  type test1 = Expect<Equal<typeof result, 2>>;
-});
+  type test1 = Expect<Equal<typeof result, 2>>
+})
 
-it("Otherwise, should return what you pass in", () => {
-  const a = returnWhatIPassInExceptFor1("a");
-  const b = returnWhatIPassInExceptFor1("b");
-  const c = returnWhatIPassInExceptFor1("c");
+it('Otherwise, should return what you pass in', () => {
+  const a = returnWhatIPassInExceptFor1('a')
+  const b = returnWhatIPassInExceptFor1('b')
+  const c = returnWhatIPassInExceptFor1('c')
 
   type tests = [
-    Expect<Equal<typeof a, "a">>,
-    Expect<Equal<typeof b, "b">>,
-    Expect<Equal<typeof c, "c">>
-  ];
-});
+    Expect<Equal<typeof a, 'a'>>,
+    Expect<Equal<typeof b, 'b'>>,
+    Expect<Equal<typeof c, 'c'>>
+  ]
+})


### PR DESCRIPTION
## My solution
```ts
function returnWhatIPassInExceptFor1<T>(t: T): T
function returnWhatIPassInExceptFor1(t: 1): 2
function returnWhatIPassInExceptFor1<T>(t: T | 1): T | 2 {
```

## Explanation
To solve this problem, we have to declare 2 func overloads.
The first one is by accepting generic and return that captured value.
The second one is by accepting literal value `1` and returning `2` in the type declaration.