### PR TITLE
Solution: 26 Document queryselector

### DIFF
--- a/src/05-function-overloads/26-document.queryselector-example.problem.ts
+++ b/src/05-function-overloads/26-document.queryselector-example.problem.ts
@@ -1,16 +1,16 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
-const divElement = document.querySelector("div");
-const spanElement = document.querySelector("span");
+const divElement = document.querySelector('div')
+const spanElement = document.querySelector('span')
 
 /**
  * Your challenge: figure out why divElement2 is NOT
  * of type HTMLDivElement.
  */
-const divElement2 = document.querySelector("div.foo");
+const divElement2 = document.querySelector<HTMLDivElement>('div.foo')
 
 type tests = [
   Expect<Equal<typeof divElement, HTMLDivElement | null>>,
   Expect<Equal<typeof spanElement, HTMLSpanElement | null>>,
   Expect<Equal<typeof divElement2, HTMLDivElement | null>>
-];
+]


### PR DESCRIPTION
## My solution
```ts
const divElement2 = document.querySelector<HTMLDivElement>('div.foo')
```

## Explanation
We can look at the type declaration file. And from there we can see this line.
```ts
querySelector<E extends Element = Element>(selectors: string): E | null;
```

Since we know `querySelector` accepting a generic, we can manually type it with `HTMLDivElement`