### PR TITLE
Solution: 28 Could be instantiated with subtype of

### DIFF
--- a/src/05-function-overloads/28-could-be-instantiated-with-subtype-of.problem.ts
+++ b/src/05-function-overloads/28-could-be-instantiated-with-subtype-of.problem.ts
@@ -1,25 +1,27 @@
-import { Equal, Expect } from "../helpers/type-utils";
+import { Equal, Expect } from '../helpers/type-utils'
 
 const obj = {
   a: 1,
   b: 2,
   c: 3,
-} as const;
+} as const
 
-type ObjKey = keyof typeof obj;
+type ObjKey = keyof typeof obj
 
-const getObjValue = <TKey extends ObjKey>(key: TKey = "a") => {
-  return obj[key];
-};
+function getObjValue(): (typeof obj)['a']
+function getObjValue<TKey extends ObjKey>(key: TKey): (typeof obj)[TKey]
+function getObjValue(key: ObjKey = 'a') {
+  return obj[key]
+}
 
-const one = getObjValue("a");
-const oneByDefault = getObjValue();
-const two = getObjValue("b");
-const three = getObjValue("c");
+const one = getObjValue('a')
+const oneByDefault = getObjValue()
+const two = getObjValue('b')
+const three = getObjValue('c')
 
 type tests = [
   Expect<Equal<typeof one, 1>>,
   Expect<Equal<typeof oneByDefault, 1>>,
   Expect<Equal<typeof two, 2>>,
   Expect<Equal<typeof three, 3>>
-];
+]


### PR DESCRIPTION
## My solution
```ts
function getObjValue(): (typeof obj)['a']
function getObjValue<TKey extends ObjKey>(key: TKey): (typeof obj)[TKey]
function getObjValue(key: ObjKey = 'a') {
  return obj[key]
}
```

## Problem
For the solution, I look at Matt's because the concept is fairly new to me and I couldn't find the answer.
The solution is by adding 2 function overloads.
1. For the case if no key being passed 
```ts
function getObjValue(): (typeof obj)['a']
```

2. For the case if a key being passed, here we could add a generic inference, because we know the key would be passed by the caller.
```ts
function getObjValue<TKey extends ObjKey>(key: TKey): (typeof obj)[TKey]
```

In the implementation signature, we don't have to declare any generic because it is the signature that facing inwards and not for outside call.