### PR TITLE
Solution: 29 Infinite scroll

### DIFF
--- a/src/06-challenges/29-infinite-scroll.problem.ts
+++ b/src/06-challenges/29-infinite-scroll.problem.ts
@@ -1,71 +1,84 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-const makeInfiniteScroll = (params: unknown) => {
-  const data = params.initialRows || [];
+function makeInfiniteScroll<T extends object>(params: {
+  key: keyof T
+  fetchRows: () => Promise<Array<T>>
+}): { scroll: () => Promise<void>; getRows: () => Array<T> }
+
+function makeInfiniteScroll<T extends object>(params: {
+  key: keyof T
+  fetchRows: () => Promise<Array<T>>
+  initialRows: Array<T>
+}): { scroll: () => Promise<void>; getRows: () => Array<T> }
+
+function makeInfiniteScroll<T extends object>(params: {
+  key: keyof T
+  fetchRows: () => Promise<Array<T>>
+  initialRows?: Array<T>
+}) {
+  const data = params.initialRows || []
 
   const scroll = async () => {
-    const rows = await params.fetchRows();
-    data.push(...rows);
-  };
+    const rows = await params.fetchRows()
+    data.push(...rows)
+  }
 
   return {
     scroll,
     getRows: () => data,
-  };
-};
+  }
+}
 
-it("Should fetch more data when scrolling", async () => {
+it('Should fetch more data when scrolling', async () => {
   const table = makeInfiniteScroll({
-    key: "id",
-    fetchRows: () => Promise.resolve([{ id: 1, name: "John" }]),
-  });
+    key: 'id',
+    fetchRows: () => Promise.resolve([{ id: 1, name: 'John' }]),
+  })
 
-  await table.scroll();
+  await table.scroll()
 
-  await table.scroll();
+  await table.scroll()
 
   expect(table.getRows()).toEqual([
-    { id: 1, name: "John" },
-    { id: 1, name: "John" },
-  ]);
-});
+    { id: 1, name: 'John' },
+    { id: 1, name: 'John' },
+  ])
+})
 
-it("Should ensure that the key is one of the properties of the row", () => {
+it('Should ensure that the key is one of the properties of the row', () => {
   makeInfiniteScroll({
     // @ts-expect-error
-    key: "name",
+    key: 'name',
     fetchRows: () =>
       Promise.resolve([
         {
-          id: "1",
+          id: '1',
         },
       ]),
-  });
-});
+  })
+})
 
-it("Should allow you to pass initialRows", () => {
+it('Should allow you to pass initialRows', () => {
   const { getRows } = makeInfiniteScroll({
-    key: "id",
+    key: 'id',
     initialRows: [
       {
         id: 1,
-        name: "John",
+        name: 'John',
       },
     ],
     fetchRows: () => Promise.resolve([]),
-  });
+  })
 
-  const rows = getRows();
+  const rows = getRows()
 
   expect(rows).toEqual([
     {
       id: 1,
-      name: "John",
+      name: 'John',
     },
-  ]);
+  ])
 
-  type tests = [
-    Expect<Equal<typeof rows, Array<{ id: number; name: string }>>>
-  ];
-});
+  type tests = [Expect<Equal<typeof rows, Array<{ id: number; name: string }>>>]
+})


### PR DESCRIPTION
## My solution
```ts
function makeInfiniteScroll<T extends object>(params: {
  key: keyof T
  fetchRows: () => Promise<Array<T>>
}): { scroll: () => Promise<void>; getRows: () => Array<T> }

function makeInfiniteScroll<T extends object>(params: {
  key: keyof T
  fetchRows: () => Promise<Array<T>>
  initialRows: Array<T>
}): { scroll: () => Promise<void>; getRows: () => Array<T> }

function makeInfiniteScroll<T extends object>(params: {
  key: keyof T
  fetchRows: () => Promise<Array<T>>
  initialRows?: Array<T>
}) 
```

## Explanation
To solve the problem, we have to declare 2 call signatures, 1 for the case with `initialRow` and another one for the case without `initialRow`

1. Call signature for case with `initialRow`
```ts
function makeInfiniteScroll<T extends object>(params: {
  key: keyof T
  fetchRows: () => Promise<Array<T>>
  initialRows: Array<T>
}): { scroll: () => Promise<void>; getRows: () => Array<T> }
```

2. Call signature for case without `initialRow`
```ts
function makeInfiniteScroll<T extends object>(params: {
  key: keyof T
  fetchRows: () => Promise<Array<T>>
}): { scroll: () => Promise<void>; getRows: () => Array<T> }
```

The last one, for the implementation signature. We have to make it optional for the `initialRows`
```ts
function makeInfiniteScroll<T extends object>(params: {
  key: keyof T
  fetchRows: () => Promise<Array<T>>
  initialRows?: Array<T>
})
```

## Notes
I got carried away by the function overload chapter and forgot this could be solved by normal generic 😄 since it doesn't have multiple return signature.