### PR TITLE
Solution: 29.2 Dynamic function arguments

### DIFF
--- a/src/06-challenges/29.2-dynamic-function-arguments.problem.ts
+++ b/src/06-challenges/29.2-dynamic-function-arguments.problem.ts
@@ -1,46 +1,49 @@
-import { it } from "vitest";
+import { it } from 'vitest'
 
 interface Events {
   click: {
-    x: number;
-    y: number;
-  };
-  focus: undefined;
+    x: number
+    y: number
+  }
+  focus: undefined
 }
 
-export const sendEvent = (event: keyof Events, ...args: any[]) => {
+export const sendEvent = <T extends keyof Events>(
+  event: T,
+  ...args: Events[T] extends undefined ? [] : [Events[T]]
+) => {
   // Send the event somewhere!
-};
+}
 
-it("Should force you to pass a second argument when you choose an event with a payload", () => {
+it('Should force you to pass a second argument when you choose an event with a payload', () => {
   // @ts-expect-error
-  sendEvent("click");
+  sendEvent('click')
 
-  sendEvent("click", {
+  sendEvent('click', {
     // @ts-expect-error
-    x: "oh dear",
-  });
+    x: 'oh dear',
+  })
 
   sendEvent(
-    "click",
+    'click',
     // @ts-expect-error
     {
       y: 1,
     }
-  );
+  )
 
-  sendEvent("click", {
+  sendEvent('click', {
     x: 1,
     y: 2,
-  });
-});
+  })
+})
 
-it("Should prevent you from passing a second argument when you choose an event without a payload", () => {
-  sendEvent("focus");
+it('Should prevent you from passing a second argument when you choose an event without a payload', () => {
+  sendEvent('focus')
 
   sendEvent(
-    "focus",
+    'focus',
     // @ts-expect-error
     {}
-  );
-});
+  )
+})


### PR DESCRIPTION
## My solution
```ts
export const sendEvent = <T extends keyof Events>(
  event: T,
  ...args: Events[T] extends undefined ? [] : [Events[T]]
)
```

## Explanation
For the solution, we need to declare a generic that capture the passed event.

And then use that generic to declare the expected argument, 
which is should be empty array to avoid making the users have to pass any argument if `undefined` and the other way around if there's `Event[T]`.

## Notes
In Typescript, we could at the name to the tuple argument.
 ```ts 
  ...args: Events[T] extends undefined ? [] : [payload: Events[T]]
 ```