### PR TITLE
Solution: 29.5 Pick

### DIFF
--- a/src/06-challenges/29.5-pick.problem.ts
+++ b/src/06-challenges/29.5-pick.problem.ts
@@ -1,29 +1,32 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-const pick = (obj: {}, picked: string[]) => {
+const pick = <TObject, TKey extends keyof TObject>(
+  obj: TObject,
+  picked: TKey[]
+) => {
   return picked.reduce((acc, key) => {
-    acc[key] = obj[key];
-    return acc;
-  }, {});
-};
+    acc[key] = obj[key]
+    return acc
+  }, {} as Record<TKey, TObject[TKey]>)
+}
 
-it("Should pick the keys from the object", () => {
+it('Should pick the keys from the object', () => {
   const result = pick(
     {
       a: 1,
       b: 2,
       c: 3,
     },
-    ["a", "b"]
-  );
+    ['a', 'b']
+  )
 
-  expect(result).toEqual({ a: 1, b: 2 });
+  expect(result).toEqual({ a: 1, b: 2 })
 
-  type test = Expect<Equal<typeof result, { a: number; b: number }>>;
-});
+  type test = Expect<Equal<typeof result, { a: number; b: number }>>
+})
 
-it("Should not allow you to pass keys which do not exist in the object", () => {
+it('Should not allow you to pass keys which do not exist in the object', () => {
   pick(
     {
       a: 1,
@@ -31,10 +34,10 @@ it("Should not allow you to pass keys which do not exist in the object", () => {
       c: 3,
     },
     [
-      "a",
-      "b",
+      'a',
+      'b',
       // @ts-expect-error
-      "d",
+      'd',
     ]
-  );
-});
+  )
+})


### PR DESCRIPTION
## My solution
```ts
const pick = <TObject, TKey extends keyof TObject>(
  obj: TObject,
  picked: TKey[]
) => {
  return picked.reduce((acc, key) => {
    acc[key] = obj[key]
    return acc
  }, {} as Record<TKey, TObject[TKey]>)
}
```

## Explanation
To solve this problem, we need 2 generic, |
1) To infer the whole object argument, 
2) To infer the pick keys, which we constrain with `keyof TObject`

```ts
const pick = <TObject, TKey extends keyof TObject>(
  obj: TObject,
  picked: TKey[]
) 
```

And then after that we can use both of the keys to type the reduce function by using assertion in the initial value.
```ts
  }, {} as Record<TKey, TObject[TKey]>)
```  