### PR TITLE
Solution: 32 Data fetcher with warning

### DIFF
--- a/src/06-challenges/32-data-fetcher-with-warning.problem.ts
+++ b/src/06-challenges/32-data-fetcher-with-warning.problem.ts
@@ -1,24 +1,28 @@
-import { expect, it } from "vitest";
-import { Equal, Expect } from "../helpers/type-utils";
+import { expect, it } from 'vitest'
+import { Equal, Expect } from '../helpers/type-utils'
 
-const fetchData = async <TResult>(url: string): Promise<TResult> => {
-  const data = await fetch(url).then((response) => response.json());
-  return data;
-};
+const fetchData = async <
+  TResult = 'You must pass a type argument to fetchData'
+>(
+  url: string
+): Promise<TResult> => {
+  const data = await fetch(url).then((response) => response.json())
+  return data
+}
 
-it("Should fetch data from an API", async () => {
+it('Should fetch data from an API', async () => {
   const data = await fetchData<{ name: string }>(
-    "https://swapi.dev/api/people/1",
-  );
-  expect(data.name).toEqual("Luke Skywalker");
+    'https://swapi.dev/api/people/1'
+  )
+  expect(data.name).toEqual('Luke Skywalker')
 
-  type tests = [Expect<Equal<typeof data, { name: string }>>];
-});
+  type tests = [Expect<Equal<typeof data, { name: string }>>]
+})
 
-it("Should force you to add a type annotation with a helpful error message", async () => {
-  const data = await fetchData("https://swapi.dev/api/people/1");
+it('Should force you to add a type annotation with a helpful error message', async () => {
+  const data = await fetchData('https://swapi.dev/api/people/1')
 
   type tests = [
-    Expect<Equal<typeof data, "You must pass a type argument to fetchData">>,
-  ];
-});
+    Expect<Equal<typeof data, 'You must pass a type argument to fetchData'>>
+  ]
+})


### PR DESCRIPTION
## My solution
```ts
const fetchData = async <
  TResult = 'You must pass a type argument to fetchData'
>
```

## Explanation
Easy peasy lemon squeezy 😄 
Just add a default value for `TResult`