### PR TITLE
Solution: 34 Internationalization

### DIFF
--- a/src/06-challenges/34-internationalization.problem.ts
+++ b/src/06-challenges/34-internationalization.problem.ts
@@ -1,46 +1,55 @@
-import { expect, it } from "vitest";
+import { expect, it } from 'vitest'
 
-type GetParamKeys<TTranslation extends string> = TTranslation extends ""
+type GetParamKeys<TTranslation extends string> = TTranslation extends ''
   ? []
   : TTranslation extends `${string}{${infer Param}}${infer Tail}`
   ? [Param, ...GetParamKeys<Tail>]
-  : [];
+  : []
 
-const translate = (translations: unknown, key: unknown, ...args: unknown[]) => {
-  const translation = translations[key];
-  const params: any = args[0] || {};
+const translate = <
+  TTranslations extends Record<TKey, string>,
+  TKey extends string
+>(
+  translations: TTranslations,
+  key: TKey,
+  ...args: GetParamKeys<TTranslations[TKey]> extends []
+    ? []
+    : [Record<GetParamKeys<TTranslations[TKey]>[number], string>]
+) => {
+  const translation = translations[key]
+  const params: any = args[0] || {}
 
-  return translation.replace(/{(\w+)}/g, (_, key) => params[key]);
-};
+  return translation.replace(/{(\w+)}/g, (_, key) => params[key])
+}
 
 // TESTS
 
 const translations = {
-  title: "Hello, {name}!",
-  subtitle: "You have {count} unread messages.",
-  button: "Click me!",
-} as const;
+  title: 'Hello, {name}!',
+  subtitle: 'You have {count} unread messages.',
+  button: 'Click me!',
+} as const
 
-it("Should translate a translation without parameters", () => {
-  const buttonText = translate(translations, "button");
+it('Should translate a translation without parameters', () => {
+  const buttonText = translate(translations, 'button')
 
-  expect(buttonText).toEqual("Click me!");
-});
+  expect(buttonText).toEqual('Click me!')
+})
 
-it("Should translate a translation WITH parameters", () => {
-  const subtitle = translate(translations, "subtitle", {
-    count: "2",
-  });
+it('Should translate a translation WITH parameters', () => {
+  const subtitle = translate(translations, 'subtitle', {
+    count: '2',
+  })
 
-  expect(subtitle).toEqual("You have 2 unread messages.");
-});
+  expect(subtitle).toEqual('You have 2 unread messages.')
+})
 
-it("Should force you to provide parameters if required", () => {
+it('Should force you to provide parameters if required', () => {
   // @ts-expect-error
-  translate(translations, "title");
-});
+  translate(translations, 'title')
+})
 
-it("Should not let you pass parameters if NOT required", () => {
+it('Should not let you pass parameters if NOT required', () => {
   // @ts-expect-error
-  translate(translations, "button", {});
-});
+  translate(translations, 'button', {})
+})


### PR DESCRIPTION
## My solution
```ts
const translate = <
  TTranslations extends Record<TKey, string>,
  TKey extends string
>(
  translations: TTranslations,
  key: TKey,
  ...args: GetParamKeys<TTranslations[TKey]> extends []
    ? []
    : [Record<GetParamKeys<TTranslations[TKey]>[number], string>]
) => {
```

## Explanation
For this problem, we have to capture both the whole object and the expected key.
By using 2 set of generics, we could capture both that we will use later for generating the arguments.

```ts
const translate = <
  TTranslations extends Record<TKey, string>,
  TKey extends string
>(
  translations: TTranslations,
  key: TKey,
```

For the arguments, Matt generously has provided us by a helper type `GetParamsKeys` that produces array of `keys`.
We could workaround this helper function to generate the expected schema in the argument.

```ts
  ...args: GetParamKeys<TTranslations[TKey]> extends []
    ? []
    : [Record<GetParamKeys<TTranslations[TKey]>[number], string>]
```

For the first case, we check if the array is empty than we just return an empty array again so the users don't have to pass anything for the argument.
And for the second case, we could create a record of keys if there are more than one key found.


## Notes
I did a little bit of mistake here.
Instead of constraining `TTranslations` by `TKey`, I should be doing the other way arond.

```ts
const translate = <
  TTranslations extends Record<string, string>,
  TKey extends keyof TTranslations
>
```


Another key takeaway, we could declare a set of generic to save us from some redundancy computation. We could call it `TParamKey` which help us to avoid calling `GetParamKeys` twice. 

```ts
const translate = <
  TTranslations extends Record<string, string>,
  TKey extends keyof TTranslations,
  TParamKeys extends string[] = GetParamKeys<TTranslations[TKey]>,
>
```